### PR TITLE
changed description, title, and name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="An interpreter for the Meatbol language"
     />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Meatbol</title>
+    <title>Meatbol Interpreter</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Meatbol",
-  "name": "Meatbol App",
+  "name": "Meatbol Interpreter",
   "icons": [
     {
       "src":"/android-chrome-192x192.png",


### PR DESCRIPTION
Changes to the manifest and package were lost when learning about Github Pages. This fix will applies the intended changes to the description, title, and name of the web app.